### PR TITLE
Porting the Windows conpty part [help needed]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "memchr"
@@ -150,12 +156,15 @@ dependencies = [
 name = "node-pty"
 version = "0.1.0"
 dependencies = [
+ "cc",
+ "cty",
  "napi",
  "napi-build",
  "napi-derive",
  "nix",
  "serde",
  "serde_derive",
+ "widestring",
  "winapi",
 ]
 
@@ -260,6 +269,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "widestring"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,13 +95,13 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.0.0-alpha.6"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385d70bc373c92377d5e099e34b4be21f5c74b1b58266a8eacba90bc31b0ec01"
+checksum = "c4cfe7fef533df6323a5aa17d75cb162850f2b045adabb9922bfbd234426a1bb"
 dependencies = [
  "ctor",
+ "lazy_static",
  "napi-sys",
- "once_cell",
  "tokio",
  "windows",
 ]
@@ -108,9 +114,9 @@ checksum = "87375bacff0768dd606ccf870eae936efd21e3245af9e7b37ae44f969d48be8a"
 
 [[package]]
 name = "napi-derive"
-version = "2.0.0-alpha.6"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255b21069692b6132217d9b8a69ce8b48f54cb16aed231cc660a55a50b493146"
+checksum = "1fb47b1f5f021abe96fcb84e7977f46c0aa645904c18cdb7b3a031e61899bf48"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -121,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.7"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc29f3bf84c188997da4a0c1ed3903cf6be6f4a6b27208862a2f50c67a5cb5f"
+checksum = "487c39117657211e9bf93acade9363eac61ceead142e4906d15ff08d29fa448d"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -135,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "1.1.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf20e0081fea04e044aa4adf74cfea8ddc0324eec2894b1c700f4cafc72a56"
+checksum = "8a385494dac3c52cbcacb393bb3b42669e7db8ab240c7ad5115f549eb061f2cc"
 
 [[package]]
 name = "nix"
@@ -300,18 +306,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbc80318ebf919219a113c41deae34aa90198e4a15e93c810a9ea1aaa4c1a78"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cae116ee11e4bce7c0a0425f2b0c866a91d86d209624b7707a7deea52da786"
+checksum = "aac7fef12f4b59cd0a29339406cc9203ab44e440ddff6b3f5a41455349fa9cf3"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -322,30 +319,30 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7d1649bbab232cde71148c6ef7bbe647f214d2154dd66347fada60de40cda7"
+checksum = "c3d027175d00b01e0cbeb97d6ab6ebe03b12330a35786cbaca5252b1c4bf5d9b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eb20b59b93fc302839f3b0df3e61de7e9606b44cb54cbeb68d71cf137309fa"
+checksum = "8793f59f7b8e8b01eda1a652b2697d87b93097198ae85f823b969ca5b89bba58"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40331d8ef3e4dcdc8982eb7de16e1f09b86f5384626a56b3a99c2a51b88ff98e"
+checksum = "8602f6c418b67024be2996c512f5f995de3ba417f4c75af68401ab8756796ae4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5937d290e39c3308147d9b877c5fa741c50f4121ea78d2d20c4a138ad365464a"
+checksum = "f3d615f419543e0bd7d2b3323af0d86ff19cbc4f816e6453f36a2c2ce889c354"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee1b76aec4e2bead4758a181b663c37af0de7ec56fe6837c10215b8d6a1635f"
+checksum = "11d95421d9ed3672c280884da53201a5c46b7b2765ca6faf34b0d71cf34a3561"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ widestring = "0.5.1"
 
 [build-dependencies]
 napi-build = "1.1.1"
+
+[target.'cfg(windows)'.build-dependencies]
 cc = "1.0.72"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,13 @@ serde_derive = "1"
 nix = "0.23.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["winuser"] }
+winapi = { version = "0.3.9", features = ["winuser", "winerror"] }
+cty = "0.2.2"
+widestring = "0.5.1"
 
 [build-dependencies]
 napi-build = "1.1.1"
+cc = "1.0.72"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = { version = "2.0.0-alpha.6", features = ["async"]}
-napi-derive = "2.0.0-alpha.6"
+napi = { version = "2.0.2", features = ["async"]}
+napi-derive = "2.0.2"
 serde = "1.0.130"
 #serde_json = "1.0.68"
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ serde_derive = "1"
 nix = "0.23.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["winuser", "winerror"] }
+winapi = { version = "0.3.9", features = [
+    "winuser", "winerror", "winbase", "winnt", "processthreadsapi"
+] }
 cty = "0.2.2"
 widestring = "0.5.1"
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,13 @@
 extern crate napi_build;
+#[cfg(target_family = "windows")]
+extern crate cc;
 
 fn main() {
   napi_build::setup();
+  #[cfg(target_family = "windows")]
+  {
+    cc::Build::new()
+        .file("src/win/conpty.cc")
+        .compile("conpty.lib");
+  }
 }

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,6 @@ fn main() {
   {
     cc::Build::new()
         .file("src/win/conpty.cc")
-        .compile("conpty.lib");
+        .compile("conpty");
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
+#[cfg(target_family = "unix")]
 mod unix;
+#[cfg(target_family = "windows")]
+mod win;
 
 //#[macro_use]
 //extern crate napi;

--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -7,6 +7,8 @@ import { UnixTerminal } from './unixTerminal';
 import * as assert from 'assert';
 import * as cp from 'child_process';
 import * as path from 'path';
+import * as tty from 'tty';
+import { constants } from 'os';
 import { pollUntil } from './testUtils.test';
 
 const FIXTURES_PATH = path.normalize(path.join(__dirname, '..', 'fixtures', 'utf8-character.txt'));
@@ -26,8 +28,9 @@ if (process.platform !== 'win32') {
           regExp = /^\/dev\/tty[p-sP-S][a-z0-9]+$/;
         }
         if (regExp) {
-          assert.ok(regExp.test((<any>term)._pty), '"' + (<any>term)._pty + '" should match ' + regExp.toString());
+          assert.ok(regExp.test(term.ptsName), '"' + term.ptsName + '" should match ' + regExp.toString());
         }
+        assert.ok(tty.isatty(term.fd));
       });
     });
 
@@ -102,6 +105,17 @@ if (process.platform !== 'win32') {
 
         term.slave.write('slave\n');
         term.master.write('master\n');
+      });
+    });
+    describe('close', () => {
+      const term = new UnixTerminal('node');
+      it('should exit when terminal is destroyed programmatically', (done) => {
+        term.on('exit', (code, signal) => {
+          assert.strictEqual(code, 0);
+          assert.strictEqual(signal, constants.signals.SIGHUP);
+          done();
+        });
+        term.destroy();
       });
     });
     describe('signals in parent and child', () => {

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -160,6 +160,10 @@ export class UnixTerminal extends Terminal {
     this._socket.write(data);
   }
 
+  /* Accessors */
+  get fd(): number { return this._fd; }
+  get ptsName(): string { return this._pty; }
+
   /**
    * openpty
    */

--- a/src/win/conpty.rs
+++ b/src/win/conpty.rs
@@ -1,4 +1,5 @@
 use std::ptr::null;
+use std::ffi::CString;
 use widestring::U16CString;
 use winapi::ctypes::wchar_t;
 use winapi::shared::winerror::SUCCEEDED;
@@ -29,14 +30,15 @@ extern "C" {
                                       out_h_out: &mut *const cty::c_void,
                                       out_out_name: &mut *const wchar_t) -> i32;
 
-  fn PtyConnect(id: cty::c_int, cmdline: *const u8, cwd: *const u8, env: *const u8) -> i32;
+  fn PtyConnect(id: cty::c_int, cmdline: *const cty::c_char, cwd: *const cty::c_char, env: *const cty::c_char) -> i32;
 }
 
 #[napi(js_name = "startProcess")]
+#[allow(dead_code)]
 fn start_process(
-  file: String,
+  _file: String,
   cols: u32, rows: u32,
-  debug: bool, pipe_name: String,
+  _debug: bool, pipe_name: String,
   conpty_inherit_cursor: bool) -> napi::Result<IConptyProcess> {
 
   let p = U16CString::from_str(pipe_name).unwrap();
@@ -69,8 +71,15 @@ fn start_process(
 }
 
 #[napi]
-fn connect(ptyId: i32, commandLine: String, cwd: String, env: Vec<String>, onexit: JsFunction) -> napi::Result<IConptyConnection> {
-    Ok(IConptyConnection { pid: 0 })
+#[allow(dead_code)]
+fn connect(pty_id: i32, cmdline: String, cwd: String, env: Vec<String>, onexit: JsFunction) -> napi::Result<IConptyConnection> {
+  let senv = (env.join("\0") + "\0\0").into_bytes();
+
+  let pid = unsafe { PtyConnect(pty_id, CString::new(cmdline)?.as_ptr(),
+      CString::new(cwd)?.as_ptr(), senv.as_ptr() as *const cty::c_char) };
+
+  /** @todo check `pid > 0` and report errors */
+  Ok(IConptyConnection { pid })
 }
 
 unsafe fn from_wchar_ptr(s: *const wchar_t) -> String {

--- a/src/win/conpty.rs
+++ b/src/win/conpty.rs
@@ -4,6 +4,11 @@ use widestring::U16CString;
 use winapi::ctypes::wchar_t;
 use winapi::shared::winerror::SUCCEEDED;
 use napi::JsFunction;
+use napi::threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode, ErrorStrategy, ThreadsafeFunction};
+use napi::threadsafe_function::ErrorStrategy::Fatal;
+use winapi::um::processthreadsapi::GetExitCodeProcess;
+use winapi::um::winbase::{INFINITE, RegisterWaitForSingleObject};
+use winapi::um::winnt::{HANDLE, PVOID, WT_EXECUTEONLYONCE};
 
 #[napi(object)]
 #[derive(Serialize, Deserialize, Debug)]
@@ -16,7 +21,12 @@ struct IConptyProcess {
 
 #[napi(object)]
 struct IConptyConnection {
-    pub pid: i32
+  pub pid: i32
+}
+
+struct ConptyBaton {
+  pub h_process: HANDLE,
+  pub async_cb: ThreadsafeFunction<u32, Fatal>
 }
 
 #[link(name = "conpty")]
@@ -30,7 +40,8 @@ extern "C" {
                                       out_h_out: &mut *const cty::c_void,
                                       out_out_name: &mut *const wchar_t) -> i32;
 
-  fn PtyConnect(id: cty::c_int, cmdline: *const cty::c_char, cwd: *const cty::c_char, env: *const cty::c_char) -> i32;
+  fn PtyConnect(id: cty::c_int, cmdline: *const cty::c_char, cwd: *const cty::c_char, env: *const cty::c_char,
+    out_h_process: &mut HANDLE) -> i32;
 }
 
 #[napi(js_name = "startProcess")]
@@ -62,6 +73,8 @@ fn start_process(
     panic!("conpty failed");
   }
 
+  // @todo SetConsoleCtrl
+
   let result = IConptyProcess {
     fd: -1, pty: pty_id,
     conin: unsafe { from_wchar_ptr(in_name) },
@@ -75,11 +88,39 @@ fn start_process(
 fn connect(pty_id: i32, cmdline: String, cwd: String, env: Vec<String>, onexit: JsFunction) -> napi::Result<IConptyConnection> {
   let senv = (env.join("\0") + "\0\0").into_bytes();
 
+  let mut h_process: HANDLE = unsafe { std::mem::zeroed() };
   let pid = unsafe { PtyConnect(pty_id, CString::new(cmdline)?.as_ptr(),
-      CString::new(cwd)?.as_ptr(), senv.as_ptr() as *const cty::c_char) };
+      CString::new(cwd)?.as_ptr(), senv.as_ptr() as *const cty::c_char, &mut h_process) };
 
-  /** @todo check `pid > 0` and report errors */
+  let async_cb = onexit.create_threadsafe_function::<_, _, _, ErrorStrategy::Fatal>(0,
+    |ctx: ThreadSafeCallContext<u32>| {
+      ctx.env.create_uint32(ctx.value).map(|v0| { vec![v0] })
+    })?;
+
+  let baton = Box::new( ConptyBaton { h_process, async_cb } );
+
+  unsafe {
+    let mut h_wait: HANDLE = std::mem::zeroed();
+    RegisterWaitForSingleObject(&mut h_wait, h_process,
+                                Some(on_exit_process_eh),
+                                Box::into_raw(baton) as *mut _,
+                                INFINITE, WT_EXECUTEONLYONCE);
+  }
+
+  /* @todo check `pid > 0` and report errors */
   Ok(IConptyConnection { pid })
+}
+
+unsafe extern "system" fn on_exit_process_eh(ctx: PVOID, _b: u8) -> () {
+  let baton = Box::from_raw(ctx as *mut ConptyBaton);
+  println!("hProcess = {:?}", baton.h_process);
+
+  let mut exit_code: u32 = 0;
+  GetExitCodeProcess(baton.h_process, &mut exit_code);
+  println!("exit code = {}", exit_code);
+
+  baton.async_cb.call(exit_code, ThreadsafeFunctionCallMode::Blocking);
+  /* @todo free the baton */
 }
 
 unsafe fn from_wchar_ptr(s: *const wchar_t) -> String {

--- a/src/win/conpty.rs
+++ b/src/win/conpty.rs
@@ -2,6 +2,7 @@ use std::ptr::null;
 use widestring::U16CString;
 use winapi::ctypes::wchar_t;
 use winapi::shared::winerror::SUCCEEDED;
+use napi::JsFunction;
 
 #[napi(object)]
 #[derive(Serialize, Deserialize, Debug)]
@@ -12,18 +13,24 @@ struct IConptyProcess {
   pub conout: String
 }
 
+#[napi(object)]
+struct IConptyConnection {
+    pub pid: i32
+}
+
 #[link(name = "conpty")]
 extern "C" {
   fn CreateNamedPipesAndPseudoConsole(cols: cty::uint32_t, rows: cty::uint32_t,
                                       flags: cty::uint32_t,
                                       pipe_name: *const u16,
+                                      out_pty_id: &mut cty::c_int,
                                       out_h_in: &mut *const cty::c_void,
                                       out_in_name: &mut *const wchar_t,
                                       out_h_out: &mut *const cty::c_void,
                                       out_out_name: &mut *const wchar_t) -> i32;
-}
 
-static mut pty_id: i32 = 1;
+  fn PtyConnect(id: cty::c_int, cmdline: *const u8, cwd: *const u8, env: *const u8) -> i32;
+}
 
 #[napi(js_name = "startProcess")]
 fn start_process(
@@ -34,6 +41,7 @@ fn start_process(
 
   let p = U16CString::from_str(pipe_name).unwrap();
 
+  let mut pty_id: cty::c_int = 0;
   let mut h_in: *const cty::c_void = null();
   let mut in_name: *const wchar_t = null();
   let mut h_out: *const cty::c_void = null();
@@ -43,6 +51,7 @@ fn start_process(
     CreateNamedPipesAndPseudoConsole(cols, rows,
                                      if conpty_inherit_cursor { 1 } else { 0 },
                                      p.as_ptr(),
+                                     &mut pty_id,
                                      &mut h_in, &mut in_name,
                                      &mut h_out, &mut out_name)
   };
@@ -52,11 +61,16 @@ fn start_process(
   }
 
   let result = IConptyProcess {
-    fd: -1, pty: unsafe { pty_id += 1; pty_id },
+    fd: -1, pty: pty_id,
     conin: unsafe { from_wchar_ptr(in_name) },
     conout: unsafe { from_wchar_ptr(out_name) }
   };
   return Ok(result);
+}
+
+#[napi]
+fn connect(ptyId: i32, commandLine: String, cwd: String, env: Vec<String>, onexit: JsFunction) -> napi::Result<IConptyConnection> {
+    Ok(IConptyConnection { pid: 0 })
 }
 
 unsafe fn from_wchar_ptr(s: *const wchar_t) -> String {

--- a/src/win/conpty.rs
+++ b/src/win/conpty.rs
@@ -1,0 +1,64 @@
+use std::ptr::null;
+use widestring::U16CString;
+use winapi::ctypes::wchar_t;
+use winapi::shared::winerror::SUCCEEDED;
+
+#[napi(object)]
+#[derive(Serialize, Deserialize, Debug)]
+struct IConptyProcess {
+  pub fd: i32,
+  pub pty: i32,
+  pub conin: String,
+  pub conout: String
+}
+
+#[link(name = "conpty")]
+extern "C" {
+  fn CreateNamedPipesAndPseudoConsole(cols: cty::uint32_t, rows: cty::uint32_t,
+                                      flags: cty::uint32_t,
+                                      pipe_name: *const u16,
+                                      out_h_in: &mut *const cty::c_void,
+                                      out_in_name: &mut *const wchar_t,
+                                      out_h_out: &mut *const cty::c_void,
+                                      out_out_name: &mut *const wchar_t) -> i32;
+}
+
+static mut pty_id: i32 = 1;
+
+#[napi(js_name = "startProcess")]
+fn start_process(
+  file: String,
+  cols: u32, rows: u32,
+  debug: bool, pipe_name: String,
+  conpty_inherit_cursor: bool) -> napi::Result<IConptyProcess> {
+
+  let p = U16CString::from_str(pipe_name).unwrap();
+
+  let mut h_in: *const cty::c_void = null();
+  let mut in_name: *const wchar_t = null();
+  let mut h_out: *const cty::c_void = null();
+  let mut out_name: *const wchar_t = null();
+
+  let hr = unsafe {
+    CreateNamedPipesAndPseudoConsole(cols, rows,
+                                     if conpty_inherit_cursor { 1 } else { 0 },
+                                     p.as_ptr(),
+                                     &mut h_in, &mut in_name,
+                                     &mut h_out, &mut out_name)
+  };
+
+  if ! SUCCEEDED(hr) {
+    panic!("conpty failed");
+  }
+
+  let result = IConptyProcess {
+    fd: -1, pty: unsafe { pty_id += 1; pty_id },
+    conin: unsafe { from_wchar_ptr(in_name) },
+    conout: unsafe { from_wchar_ptr(out_name) }
+  };
+  return Ok(result);
+}
+
+unsafe fn from_wchar_ptr(s: *const wchar_t) -> String {
+  U16CString::from_ptr_str(s).to_string_lossy().into()
+}

--- a/src/win/mod.rs
+++ b/src/win/mod.rs
@@ -1,0 +1,1 @@
+pub mod conpty;

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -11,6 +11,7 @@ import { Socket } from 'net';
 import { ArgvOrCommandLine } from './types';
 import { fork } from 'child_process';
 import { ConoutConnection } from './windowsConoutConnection';
+import { loadBinding } from '@node-rs/helper';
 
 let conptyNative: IConptyNative;
 let winptyNative: IWinptyNative;
@@ -62,17 +63,7 @@ export class WindowsPtyAgent {
     }
     if (this._useConpty) {
       if (!conptyNative) {
-        try {
-          conptyNative = require('../build/Release/conpty.node');
-        } catch (outerError) {
-          try {
-            conptyNative = require('../build/Debug/conpty.node');
-          } catch (innerError) {
-            console.error('innerError', innerError);
-            // Re-throw the exception from the Release require if the Debug require fails as well
-            throw outerError;
-          }
-        }
+        conptyNative = loadBinding(path.join(__dirname, '..'), 'node-pty', 'node-pty');
       }
     } else {
       if (!winptyNative) {

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -81,7 +81,7 @@ function pollForProcessTreeSize(pid: number, size: number, intervalMs: number = 
         if (tries * intervalMs >= timeoutMs) {
           clearInterval(interval);
           assert.fail(`Bad process state, expected: ${size}, actual: ${list.length}`);
-          resolve();
+          resolve(null);
         }
       });
     }, intervalMs);


### PR DESCRIPTION
I am trying to port the conpty functionality to Rust as well. I have managed to get it more or less right, but I'm a bit stuck due to my being unfamiliar with Windows API etc.

Currently, I can run a subprocess and get its output, e.g.
```js
const pty = require('.');
var a = pty.spawn("ipconfig.exe", []);
a.on('data', console.log);
```

And I even get the callback when the process exits. But Node.js does not exit after cleanup... so there must be some resource still hanging there. Can you try this and perhaps help my find what it is?

BTW the code is messy and needs cleanup, of course. But I've got to solve this issue, otherwise this branch is just borked.